### PR TITLE
v0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.23-alpine  AS build
 
 WORKDIR /go/src/github.com/nicolaka/tfbi
 
-ARG tag="v0.3"
+ARG tag="v0.4"
 
 COPY . .
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -12,7 +12,7 @@ FROM golang:1.23-alpine AS build
 
 WORKDIR /go/src/github.com/nicolaka/tfbi
 
-ARG tag="v0.3"
+ARG tag="v0.4"
 
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -82,7 +82,15 @@ $ docker compose up -d
 
 4. Now you can access the dashboard using http://localhost:3000
 
-> Note: It's recommended to create a Grafana user/password and login using it, otherwise you'll continue receiving auth warning logs in Grafan.
+> Note: It's recommended to create a Grafana user/password and login using it, otherwise you'll continue receiving auth warning logs in Grafana
+
+5. Depending on the number of organizations you have and number of workspaces, projects, modules per organization, you might need to tweak the `scrape_interval` and `scrape_timeout` in `prometheus/prometheus.yml` as follows. Default is 5m (interval) and 3m(timeout).
+
+| Organization Size	| scrape_interval	| scrape_timeout 
+| - | - | - | 
+Small (up to 500 Workspaces) |	1–5m	| 1–2m
+Medium (500-2500 Workspaces) |	5–10m |	3–5m
+Large (2500+ Workspaces) |	10–30m	| 5–15m
 
 
 ## Local Development & Contribution

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -3,7 +3,7 @@ group "default" {
 }
 
 variable "TAG" {
-  default = "v0.3"
+  default = "v0.4"
 }
 
 target "tfbi-exporter" {

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -11,7 +11,7 @@ rule_files:
 scrape_configs:
   - job_name: 'tf_exporter'
     # Override the global default and scrape targets. For larger workspace sets, scraper needs time to go through all of them, hence the 3m/90s intervals
-    scrape_interval: 3m
-    scrape_timeout: 90s
+    scrape_interval: 5m
+    scrape_timeout: 3m
     static_configs:
     - targets: ['exporter:9100']

--- a/scale-test-tf/main.tf
+++ b/scale-test-tf/main.tf
@@ -1,0 +1,46 @@
+provider "tfe" {
+  hostname = "app.terraform.io"
+  organization = var.org
+}
+
+variable "org" {
+  default = "test"
+}
+
+variable "project" {
+  default = "test"
+}
+
+data "tfe_project" "project" {
+    name = var.project
+
+variable "workspace_count" {
+  default = 0
+}
+
+variable "team_count" {
+  default = 0
+}
+
+variable "project_count" {
+  default = 0
+}
+
+resource "tfe_team" "team" {
+   count = var.team_count
+   name  = "scale-team-${count.index + 1}"
+   organization = var.org
+}
+
+resource "tfe_workspace" "ws" {
+  count = var.workspace_count
+  name  = "scale-workspace-${count.index + 1}"
+  organization = var.org
+  project_id = data.tfe_project.project.id
+}
+
+resource "tfe_project" "project" {
+  count = var.project_count
+  name  = "scale-project-${count.index + 1}"
+  organization = var.org
+}


### PR DESCRIPTION
Release 0.4
- implemented bounded parallelism for page fetching within each organization to optimize scraping time
- Updated readme to provide guidance on adjusting scrape interval/timeout paramters
- added terraform code used to scale test workspaces/projects